### PR TITLE
Fix island removal workflow

### DIFF
--- a/Source/DiggerEditor/Private/DiggerEdModeToolkit.cpp
+++ b/Source/DiggerEditor/Private/DiggerEdModeToolkit.cpp
@@ -1981,6 +1981,24 @@ void FDiggerEdModeToolkit::OnConvertToPhysicsActorClicked()
     }
 }
 
+void FDiggerEdModeToolkit::OnRemoveIslandClicked()
+{
+    if (SelectedIslandIndex != INDEX_NONE && Islands.IsValidIndex(SelectedIslandIndex))
+    {
+        const FIslandData Island = Islands[SelectedIslandIndex];
+
+        ADiggerManager* LocalManager = GetDiggerManager();
+        if (LocalManager)
+        {
+            LocalManager->RemoveIslandVoxels(Island);
+        }
+
+        Islands.RemoveAt(SelectedIslandIndex);
+        SelectedIslandIndex = INDEX_NONE;
+        RebuildIslandGrid();
+    }
+}
+
 
 
 //Make Island Section
@@ -2069,7 +2087,11 @@ TSharedRef<SWidget> FDiggerEdModeToolkit::MakeIslandsSection()
                     SNew(SButton)
                     .Text(FText::FromString("Remove"))
                     .IsEnabled_Lambda([this]() { return SelectedIslandIndex != INDEX_NONE; })
-                    .OnClicked_Lambda([this]() { /* Remove logic here */ return FReply::Handled(); })
+                    .OnClicked_Lambda([this]()
+                    {
+                        OnRemoveIslandClicked();
+                        return FReply::Handled();
+                    })
                 ]
                 + SHorizontalBox::Slot().AutoWidth().Padding(2)
                 [

--- a/Source/DiggerEditor/Public/DiggerEdModeToolkit.h
+++ b/Source/DiggerEditor/Public/DiggerEdModeToolkit.h
@@ -243,7 +243,8 @@ private:
 	TSharedRef<SWidget> MakeRotationRow(const FText& Label, float& Value);
 	TSharedRef<SWidget> MakeOffsetRow(const FText& Label, double& Value);
 	TSharedRef<SWidget> MakeOffsetRow(const FText& Label, float& Value);
-	void OnConvertToPhysicsActorClicked();
+        void OnConvertToPhysicsActorClicked();
+        void OnRemoveIslandClicked();
 	TSharedRef<SWidget> MakeIslandsSection();
 
 	TSharedRef<SWidget> MakeLabeledSliderRow(

--- a/Source/DiggerProUnreal/Private/DiggerManager.cpp
+++ b/Source/DiggerProUnreal/Private/DiggerManager.cpp
@@ -1623,6 +1623,7 @@ void ADiggerManager::RemoveIslandVoxels(const FIslandData& Island)
         if (Grid->RemoveVoxel(LocalVoxel))
         {
             Removed++;
+            (*ChunkPtr)->MarkDirty();
         }
     }
 


### PR DESCRIPTION
## Summary
- add OnRemoveIslandClicked and hook up remove button
- mark chunks dirty after removing island voxels

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6884e3363030832f9a3306bd5b55a6aa