### PR TITLE
Fix lobby connection initialization

### DIFF
--- a/Plugins/SocketIOClient/Source/SocketIOClient/Private/SocketIOLobbyManager.cpp
+++ b/Plugins/SocketIOClient/Source/SocketIOClient/Private/SocketIOLobbyManager.cpp
@@ -5,6 +5,7 @@
 #include "Async/Async.h"
 #include "SIOJsonValue.h"
 #include "SIOJsonObject.h"
+#include "SocketIOFunctionLibrary.h"
 
 USocketIOLobbyManager::USocketIOLobbyManager()
 {
@@ -54,8 +55,8 @@ void USocketIOLobbyManager::Initialize(UWorld* WorldContext)
         SocketIOClient = nullptr;
     }
 
-    // Create new client component
-    SocketIOClient = NewObject<USocketIOClientComponent>(WorldContext);
+    // Create new client component using helper to ensure proper initialization
+    SocketIOClient = USocketIOFunctionLibrary::ConstructSocketIOComponent(WorldContext);
     if (!SocketIOClient)
     {
         UE_LOG(LogTemp, Error, TEXT("%s: Failed to create SocketIOClientComponent"), *FString(__FUNCTION__));


### PR DESCRIPTION
## Summary
- fix crash when connecting to lobby server by constructing `USocketIOClientComponent` with provided helper
- include missing header for the helper

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688ccfb1405c832f89d01b3f2177ae45