### PR TITLE
Fix circular dependency in island management headers

### DIFF
--- a/Source/DiggerEditor/Public/DiggerEdModeToolkit.h
+++ b/Source/DiggerEditor/Public/DiggerEdModeToolkit.h
@@ -12,15 +12,15 @@
 #include "Toolkits/BaseToolkit.h"
 #include "FCustomBrushEntry.h"
 #include "FLightBrushTypes.h"
-#include "SocketIOLobbyManager.h"   
+#include "SocketIOLobbyManager.h"
 #include "Widgets/Layout/SSeparator.h"
+#include "IslandData.h"
 #include "DiggerEdModeToolkit.generated.h" // This MUST be the last include
 
 
 
 class USocketIOLobbyManager;
 class IWebSocket;
-struct FIslandData;
 class ADiggerManager;
 class SUniformGridPanel;
 

--- a/Source/DiggerProUnreal/Public/DiggerManager.h
+++ b/Source/DiggerProUnreal/Public/DiggerManager.h
@@ -16,6 +16,7 @@
 #include "GameFramework/Actor.h"
 #include "FBrushStroke.h"
 #include "HoleShapeLibrary.h"
+#include "IslandData.h"
 
 #include "AssetToolsModule.h"
 #include "FCustomSDFBrush.h"
@@ -37,7 +38,6 @@
 #include "DiggerManager.generated.h"
 
 class UVoxelBrushShape;
-class IslandData;
 class AIslandActor;
 
 
@@ -79,36 +79,6 @@ struct FDebugBrushSettings
 #if WITH_EDITOR
 class FDiggerEdModeToolkit;
 #endif
-
-
-// New struct to track voxel storage location
-USTRUCT(BlueprintType)
-struct FVoxelInstance
-{
-    GENERATED_BODY()
-
-    FVoxelInstance()
-        : GlobalVoxel(FIntVector::ZeroValue)
-        , ChunkCoords(FIntVector::ZeroValue)
-        , LocalVoxel(FIntVector::ZeroValue)
-    {}
-
-    FVoxelInstance(const FIntVector& InGlobal, const FIntVector& InChunk, const FIntVector& InLocal)
-        : GlobalVoxel(InGlobal)
-        , ChunkCoords(InChunk)
-        , LocalVoxel(InLocal)
-    {}
-
-    UPROPERTY(BlueprintReadWrite)
-    FIntVector GlobalVoxel;
-    
-    UPROPERTY(BlueprintReadWrite)
-    FIntVector ChunkCoords;
-    
-    UPROPERTY(BlueprintReadWrite)
-    FIntVector LocalVoxel;
-};
-
 
 
 // Brush batching

--- a/Source/DiggerProUnreal/Public/IslandData.h
+++ b/Source/DiggerProUnreal/Public/IslandData.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "CoreMinimal.h"
+#include "VoxelInstance.h"
 #include "IslandData.generated.h"
 
 // Helper struct for an island

--- a/Source/DiggerProUnreal/Public/SparseVoxelGrid.h
+++ b/Source/DiggerProUnreal/Public/SparseVoxelGrid.h
@@ -7,13 +7,13 @@
 #include "UObject/Object.h"
 #include "HAL/CriticalSection.h"
 #include "Containers/Queue.h"
+#include "IslandData.h"
 #include "SparseVoxelGrid.generated.h"
 
 // Forward declarations
 class ADiggerManager;
 class UVoxelChunk;
 class UWorld;
-struct FIslandData; // Defined elsewhere (e.g., DiggerManager.h) — do NOT redefine here.
 
 // Minimal voxel payload (kept as a USTRUCT for future extensibility)
 USTRUCT(BlueprintType)

--- a/Source/DiggerProUnreal/Public/VoxelInstance.h
+++ b/Source/DiggerProUnreal/Public/VoxelInstance.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "VoxelInstance.generated.h"
+
+USTRUCT(BlueprintType)
+struct FVoxelInstance
+{
+    GENERATED_BODY();
+
+    FVoxelInstance()
+        : GlobalVoxel(FIntVector::ZeroValue)
+        , ChunkCoords(FIntVector::ZeroValue)
+        , LocalVoxel(FIntVector::ZeroValue)
+    {}
+
+    FVoxelInstance(const FIntVector& InGlobal, const FIntVector& InChunk, const FIntVector& InLocal)
+        : GlobalVoxel(InGlobal)
+        , ChunkCoords(InChunk)
+        , LocalVoxel(InLocal)
+    {}
+
+    UPROPERTY(BlueprintReadWrite)
+    FIntVector GlobalVoxel;
+
+    UPROPERTY(BlueprintReadWrite)
+    FIntVector ChunkCoords;
+
+    UPROPERTY(BlueprintReadWrite)
+    FIntVector LocalVoxel;
+};
+


### PR DESCRIPTION
## Summary
- Move `FVoxelInstance` into its own header to decouple island and manager types
- Include `IslandData.h` where needed and remove cross-header dependency
- Update editor/toolkit headers accordingly

## Testing
- `UnrealBuildTool -help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a2a922d4832f8366ea4dcff2a2db