### PR TITLE
Fix brush preview shapes

### DIFF
--- a/Source/DiggerEditor/Private/BrushPreviewActor.cpp
+++ b/Source/DiggerEditor/Private/BrushPreviewActor.cpp
@@ -36,10 +36,12 @@ void ABrushPreviewActor::SetVisible(bool bVisible)
 
 void ABrushPreviewActor::Initialize(UStaticMesh* ShapeMesh, UMaterialInterface* BaseMat)
 {
+    // Preload all meshes up front so switching shapes later is seamless.
+    EnsureMeshesLoaded();
+
     if (ShapeMesh)
         PreviewMesh->SetStaticMesh(ShapeMesh);
 
-    // Skip material for now
     if (BaseMat)
     {
         MID = UMaterialInstanceDynamic::Create(BaseMat, this);
@@ -126,6 +128,11 @@ void ABrushPreviewActor::SetShape(EBrushPreviewShape NewShape)
     if (NewMesh)
     {
         PreviewMesh->SetStaticMesh(NewMesh);
+        if (MID)
+        {
+            // Ensure our preview material stays applied when swapping meshes.
+            PreviewMesh->SetMaterial(0, MID);
+        }
 
         // Update cached unit radius from the new mesh
         const FBoxSphereBounds B = NewMesh->GetBounds();

--- a/Source/DiggerEditor/Private/DiggerEdMode.cpp
+++ b/Source/DiggerEditor/Private/DiggerEdMode.cpp
@@ -277,10 +277,35 @@ FDiggerEdMode::FBrushUIParams FDiggerEdMode::GetCurrentBrushUI() const
         P.Falloff    = DiggerToolkit ? DiggerToolkit->GetBrushFalloff() : 0.25f;
         P.bAdd       = DiggerToolkit ? DiggerToolkit->IsDigMode() : true;
         //P.CellSize   = (DM && DM->Subdivisions>0) ? DM->TerrainGridSize / float(DM->Subdivisions) : 50.f;
+
+        // Map the active editor brush type to our preview enum so the
+        // correct preview mesh is displayed for the selected tool.
+        switch (DiggerToolkit->GetCurrentBrushType())
+        {
+        case EVoxelBrushType::Cube:
+        case EVoxelBrushType::AdvancedCube:
+            P.ShapeType = static_cast<uint8>(EBrushPreviewShape::Box);
+            break;
+        case EVoxelBrushType::Cylinder:
+            P.ShapeType = static_cast<uint8>(EBrushPreviewShape::Cylinder);
+            break;
+        case EVoxelBrushType::Capsule:
+            P.ShapeType = static_cast<uint8>(EBrushPreviewShape::Capsule);
+            break;
+        case EVoxelBrushType::Cone:
+        case EVoxelBrushType::Pyramid:
+            P.ShapeType = static_cast<uint8>(EBrushPreviewShape::Cone);
+            break;
+        case EVoxelBrushType::Torus:
+            P.ShapeType = static_cast<uint8>(EBrushPreviewShape::Torus);
+            break;
+        case EVoxelBrushType::Sphere:
+        case EVoxelBrushType::Icosphere:
+        default:
+            P.ShapeType = static_cast<uint8>(EBrushPreviewShape::Sphere);
+            break;
+        }
     }
-    
-    // Map your real brush type to enum (keep a stable mapping)
-    // P.ShapeType  = MapYourBrushTypeToPreviewEnum(TK ? TK->GetBrushType() : EMyBrushType::Sphere);
 
     return P;
 }
@@ -303,19 +328,8 @@ void FDiggerEdMode::UpdatePreviewAtCursor(FEditorViewportClient* InViewportClien
     Preview->SetVisible(true);
     const FBrushUIParams P = GetCurrentBrushUI();
 
-    EBrushPreviewShape Shape = EBrushPreviewShape::Sphere; // map your type -> shape here
-    switch (P.ShapeType)
-    {
-    default:
-    case 0: Shape = EBrushPreviewShape::Sphere; break;
-    case 1: Shape = EBrushPreviewShape::Box; break;
-    case 2: Shape = EBrushPreviewShape::Capsule; break;
-    case 3: Shape = EBrushPreviewShape::Cylinder; break;
-    case 4: Shape = EBrushPreviewShape::Cone; break;
-    case 5: Shape = EBrushPreviewShape::RoundBox; break;
-    case 6: Shape = EBrushPreviewShape::Ellipsoid; break;
-    case 7: Shape = EBrushPreviewShape::Torus; break;
-    }
+    // The shape type is provided by GetCurrentBrushUI via the toolkit.
+    const EBrushPreviewShape Shape = static_cast<EBrushPreviewShape>(P.ShapeType);
 
     Preview->UpdatePreview(
         Hit.Location,


### PR DESCRIPTION
## Summary
- preload preview meshes and keep material when swapping shapes
- map selected brush type to preview shape so correct mesh is shown

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e1b35a90832f99a98be9825d0fa5