### PR TITLE
Fix island alignment and mesh assignment

### DIFF
--- a/Source/DiggerProUnreal/Private/DiggerManager.cpp
+++ b/Source/DiggerProUnreal/Private/DiggerManager.cpp
@@ -86,7 +86,8 @@ class FDiggerEdMode;
 class MeshDescriptors;
 class StaticMeshAttributes;
 
-
+// Offset applied to all island world positions to correct misalignment
+static const FVector WORLD_ISLAND_OFFSET(-1600.f, -1600.f, -1600.f);
 
 
 static UHoleShapeLibrary* LoadDefaultHoleLibrary()
@@ -1719,7 +1720,7 @@ AIslandActor* ADiggerManager::SpawnIslandActorWithMeshData(
         TArray<FVector> LocalVertices = MeshData.Vertices;
         for (FVector& Vertex : LocalVertices)
         {
-            Vertex -= SpawnLocation * 2;
+            Vertex -= SpawnLocation;
         }
 
         IslandActor->ProcMesh->CreateMeshSection_LinearColor(
@@ -1784,6 +1785,7 @@ FIslandMeshData ADiggerManager::GenerateIslandMeshFromStoredData(const FIslandDa
         IslandWorldCenter += FVoxelConversion::GlobalVoxelToWorld(Instance.GlobalVoxel);
     }
     IslandWorldCenter /= InstanceCount;
+    IslandWorldCenter += WORLD_ISLAND_OFFSET;
 
     MarchingCubes->GenerateMeshFromGrid(
         ExtractedGrid,
@@ -1804,7 +1806,7 @@ FIslandMeshData ADiggerManager::GenerateIslandMeshFromStoredData(const FIslandDa
 
         for (const auto& Pair : IslandData.VoxelDataMap)
         {
-            FVector WorldPos = FVoxelConversion::GlobalVoxelToWorld(Pair.Key);
+            FVector WorldPos = FVoxelConversion::GlobalVoxelToWorld(Pair.Key) + WORLD_ISLAND_OFFSET;
             DrawDebugBox(GetWorld(), WorldPos, FVector(VoxelSize * 0.5f), FColor::Red, false, 10.0f);
         }
     }
@@ -1890,8 +1892,8 @@ void ADiggerManager::HighlightIslandByID(const FName& IslandID)
     int32 DebugCount = 0;
     for (const FVoxelInstance& Instance : Island->VoxelInstances)
     {
-        // ✅ Use global voxel position for world alignment
-        FVector WorldPos = FVoxelConversion::GlobalVoxelToWorld(Instance.GlobalVoxel);
+        // ✅ Use global voxel position for world alignment and apply world offset
+        FVector WorldPos = FVoxelConversion::GlobalVoxelToWorld(Instance.GlobalVoxel) + WORLD_ISLAND_OFFSET;
 
         if (DebugCount < 3)
         {
@@ -1906,7 +1908,8 @@ void ADiggerManager::HighlightIslandByID(const FName& IslandID)
         Transform.SetLocation(WorldPos);
         Transform.SetScale3D(Scale * 1.3f);
 
-        VoxelDebugMesh->AddInstance(Transform);
+        // Use world-space transform so highlight matches island position
+        VoxelDebugMesh->AddInstanceWorldSpace(Transform);
         DebugCount++;
     }
 
@@ -1915,7 +1918,8 @@ void ADiggerManager::HighlightIslandByID(const FName& IslandID)
     CenterTransform.SetLocation(Island->Location);
     CenterTransform.SetScale3D(FVector(3.0f));
 
-    VoxelDebugMesh->AddInstance(CenterTransform);
+    // Add island center marker using world-space transform
+    VoxelDebugMesh->AddInstanceWorldSpace(CenterTransform);
     DebugCount++;
 
     UE_LOG(LogTemp, Warning, TEXT("[IslandDebug] Island.Location debug box at: %s"), *Island->Location.ToString());
@@ -3539,7 +3543,7 @@ TArray<FIslandData> ADiggerManager::DetectUnifiedIslands()
         EnhancedIsland.IslandID = FName(*FString::Printf(TEXT("Island_%s"), *Hash));
         EnhancedIsland.IslandName = FString::Printf(TEXT("Island %d"), FinalIslands.Num());
         EnhancedIsland.PersistentUID = FGuid::NewGuid();
-        EnhancedIsland.Location = DedupIsland.Location;
+        EnhancedIsland.Location = DedupIsland.Location + WORLD_ISLAND_OFFSET;
         EnhancedIsland.ReferenceVoxel = DedupIsland.ReferenceVoxel;
 
         TSet<FIntVector> IslandGlobalVoxels(DedupIsland.Voxels);


### PR DESCRIPTION
## Summary
- apply global -1600 world offset so islands highlight, generate, and convert at correct level locations
- correct mesh vertex translation when spawning island actors for proper static mesh conversion

## Testing
- `g++ -fsyntax-only Source/DiggerProUnreal/Private/DiggerManager.cpp` *(fails: DiggerManager.h: No such file or directory)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acca9a5cec832f85724be9d410849b