### PR TITLE
Restore debug flag entry struct alias

### DIFF
--- a/Source/DiggerEditor/Private/DiggerEdModeToolkit.cpp
+++ b/Source/DiggerEditor/Private/DiggerEdModeToolkit.cpp
@@ -269,6 +269,8 @@ void FDiggerEdModeToolkit::Init(const TSharedPtr<IToolkitHost>& InitToolkitHost)
 
     static float DummyFloat = 0.0f;
 
+    TSharedPtr<SVerticalBox> DebugFlagListContainer;
+
     ToolkitWidget = SNew(SVerticalBox)
         
 
@@ -406,62 +408,10 @@ void FDiggerEdModeToolkit::Init(const TSharedPtr<IToolkitHost>& InitToolkitHost)
         ]
         .BodyContent()
         [
-            SNew(SVerticalBox)
+            SAssignNew(DebugFlagListContainer, SVerticalBox)
             + SVerticalBox::Slot().AutoHeight().Padding(8, 12, 8, 4)
             [
                 SNew(STextBlock).Text(FText::FromString("General Debug Flags"))
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Verbose"), &DiggerDebug::Verbose)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Performance"), &DiggerDebug::Performance)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Normals"), &DiggerDebug::Normals)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Error"), &DiggerDebug::Error)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Holes"), &DiggerDebug::Holes)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Landscape"), &DiggerDebug::Landscape)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Voxel Conversion"), &DiggerDebug::VoxelConv)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Islands"), &DiggerDebug::Islands)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Brush"), &DiggerDebug::Brush)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Casts"), &DiggerDebug::Casts)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Threads"), &DiggerDebug::Threads)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Manager"), &DiggerDebug::Manager)
-            ]
-            + SVerticalBox::Slot().AutoHeight().Padding(1)
-            [
-                this->MakeDebugCheckbox(TEXT("Caves"), &DiggerDebug::Caves)
             ]
         ]
     ];
@@ -480,6 +430,20 @@ void FDiggerEdModeToolkit::Init(const TSharedPtr<IToolkitHost>& InitToolkitHost)
     //
     
     LoadDMMState();     // <- restore mode/profile
+
+    if (DebugFlagListContainer.IsValid())
+    {
+        const TArray<DiggerDebug::FDiggerDebugFlag>& FlagEntries = DiggerDebug::GetAllFlags();
+        for (const DiggerDebug::FDiggerDebugFlag& FlagEntry : FlagEntries)
+        {
+            DebugFlagListContainer->AddSlot()
+                .AutoHeight()
+                .Padding(1.0f)
+                [
+                    MakeDebugCheckbox(FlagEntry)
+                ];
+        }
+    }
 
     FModeToolkit::Init(InitToolkitHost);
 }

--- a/Source/DiggerEditor/Private/DiggerEdModeToolkit.cpp
+++ b/Source/DiggerEditor/Private/DiggerEdModeToolkit.cpp
@@ -1923,6 +1923,11 @@ void FDiggerEdModeToolkit::ClearBrushDigPreviewOverride()
     bUseBrushDigPreviewOverride = false;
 }
 
+TSharedRef<SWidget> FDiggerEdModeToolkit::MakeDebugCheckbox(const FDiggerDebug::FFlagEntry& FlagEntry)
+{
+    return MakeDebugCheckbox(FlagEntry.Key.ToString(), FlagEntry.Value);
+}
+
 TSharedRef<SWidget> FDiggerEdModeToolkit::MakeDebugCheckbox(const FString& Label, bool* FlagPtr)
 {
     return SNew(SCheckBox)

--- a/Source/DiggerEditor/Public/DiggerEdModeToolkit.h
+++ b/Source/DiggerEditor/Public/DiggerEdModeToolkit.h
@@ -528,7 +528,8 @@ private:
 	ADiggerManager* GetDiggerManager();
 //SubSubSections
 	TSharedRef<SWidget> MakeIslandGridWidget();
-	TSharedRef<SWidget> MakeDebugCheckbox(const FString& Label, bool* FlagPtr);
+        TSharedRef<SWidget> MakeDebugCheckbox(const FString& Label, bool* FlagPtr);
+        TSharedRef<SWidget> MakeDebugCheckbox(const FDiggerDebug::FFlagEntry& FlagEntry);
 	TSharedRef<SWidget> MakeAngleButton(float Angle, float& Target, const FString& Label);
     TSharedRef<SWidget> MakeAngleButton(double Angle, double& Target, const FString& Label);
     TSharedRef<SWidget> MakeMirrorButton(float& Target, const FString& Label);

--- a/Source/DiggerProUnreal/Private/DiggerDebug.cpp
+++ b/Source/DiggerProUnreal/Private/DiggerDebug.cpp
@@ -1,0 +1,54 @@
+#include "DiggerDebug.h"
+
+FDiggerDebug& FDiggerDebug::Get()
+{
+    static FDiggerDebug Instance;
+    return Instance;
+}
+
+FDiggerDebug::FDiggerDebug()
+{
+    RegisterFlag(TEXT("Verbose"), Verbose);
+    RegisterFlag(TEXT("Performance"), Performance);
+    RegisterFlag(TEXT("Cache"), Cache);
+    RegisterFlag(TEXT("Normals"), Normals);
+    RegisterFlag(TEXT("Error"), Error);
+    RegisterFlag(TEXT("Holes"), Holes);
+    RegisterFlag(TEXT("Landscape"), Landscape);
+    RegisterFlag(TEXT("VoxelConv"), VoxelConv);
+    RegisterFlag(TEXT("Mesh"), Mesh);
+    RegisterFlag(TEXT("Islands"), Islands);
+    RegisterFlag(TEXT("Brush"), Brush);
+    RegisterFlag(TEXT("Context"), Context);
+    RegisterFlag(TEXT("UserConv"), UserConv);
+    RegisterFlag(TEXT("IO"), IO);
+    RegisterFlag(TEXT("Threads"), Threads);
+    RegisterFlag(TEXT("Space"), Space);
+    RegisterFlag(TEXT("Chunks"), Chunks);
+    RegisterFlag(TEXT("Voxels"), Voxels);
+    RegisterFlag(TEXT("Casts"), Casts);
+    RegisterFlag(TEXT("Delegates"), Delegates);
+    RegisterFlag(TEXT("Manager"), Manager);
+    RegisterFlag(TEXT("Caves"), Caves);
+    RegisterFlag(TEXT("Lights"), Lights);
+    RegisterFlag(TEXT("Flags"), Flags);
+    RegisterFlag(TEXT("VoxelModificationReports"), VoxelModificationReports);
+    RegisterFlag(TEXT("Seams"), Seams);
+}
+
+void FDiggerDebug::RegisterFlag(const TCHAR* FlagName, bool& FlagRef)
+{
+    const FName Name(FlagName);
+    FlagRegistry.Add(Name, &FlagRef);
+    FlagList.Emplace(Name, &FlagRef);
+}
+
+bool* FDiggerDebug::FindFlag(const FName& FlagName)
+{
+    if (bool** Result = FlagRegistry.Find(FlagName))
+    {
+        return *Result;
+    }
+
+    return nullptr;
+}

--- a/Source/DiggerProUnreal/Public/DiggerDebug.h
+++ b/Source/DiggerProUnreal/Public/DiggerDebug.h
@@ -2,6 +2,20 @@
 
 #include "CoreMinimal.h"
 
+/** Plain-old-data descriptor used to expose a debug flag and its bool pointer. */
+struct FDiggerDebugFlag
+{
+    FDiggerDebugFlag() = default;
+    FDiggerDebugFlag(const FName& InKey, bool* InValue)
+        : Key(InKey)
+        , Value(InValue)
+    {
+    }
+
+    FName Key;
+    bool* Value = nullptr;
+};
+
 /**
  * Singleton container that owns the Digger debug flags so that the editor UI
  * can discover and mutate them at runtime instead of relying on global
@@ -10,27 +24,8 @@
 class FDiggerDebug
 {
 public:
-    /**
-     * Lightweight record describing a single debug flag. The structure mimics
-     * the previous `FDiggerDebugFlag` POD type so existing call sites can
-     * continue to interact with the debug system without code changes while we
-     * expose the data through a central registry.
-     */
-    struct FFlagEntry
-    {
-        FFlagEntry() = default;
-        FFlagEntry(const FName& InKey, bool* InValue)
-            : Key(InKey)
-            , Value(InValue)
-        {
-        }
-
-        FName Key;
-        bool* Value = nullptr;
-    };
-
     using FFlagRegistry = TMap<FName, bool*>;
-    using FFlagList = TArray<FFlagEntry>;
+    using FFlagList = TArray<FDiggerDebugFlag>;
 
     /** Retrieve the singleton instance. */
     static FDiggerDebug& Get();
@@ -86,7 +81,7 @@ namespace DiggerDebug
 {
     inline FDiggerDebug& Get() { return FDiggerDebug::Get(); }
 
-    using FDiggerDebugFlag = FDiggerDebug::FFlagEntry;
+    using FDiggerDebugFlag = ::FDiggerDebugFlag;
 
     inline bool& Verbose = FDiggerDebug::Get().Verbose;
     inline bool& Performance = FDiggerDebug::Get().Performance;

--- a/Source/DiggerProUnreal/Public/DiggerDebug.h
+++ b/Source/DiggerProUnreal/Public/DiggerDebug.h
@@ -1,33 +1,132 @@
-// DiggerDebug.h
-
 #pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * Singleton container that owns the Digger debug flags so that the editor UI
+ * can discover and mutate them at runtime instead of relying on global
+ * variables defined in a header.
+ */
+class FDiggerDebug
+{
+public:
+    /**
+     * Lightweight record describing a single debug flag. The structure mimics
+     * the previous `FDiggerDebugFlag` POD type so existing call sites can
+     * continue to interact with the debug system without code changes while we
+     * expose the data through a central registry.
+     */
+    struct FFlagEntry
+    {
+        FFlagEntry() = default;
+        FFlagEntry(const FName& InKey, bool* InValue)
+            : Key(InKey)
+            , Value(InValue)
+        {
+        }
+
+        FName Key;
+        bool* Value = nullptr;
+    };
+
+    using FFlagRegistry = TMap<FName, bool*>;
+    using FFlagList = TArray<FFlagEntry>;
+
+    /** Retrieve the singleton instance. */
+    static FDiggerDebug& Get();
+
+    /** Map of all debug flag names to the underlying bool pointers. */
+    const FFlagRegistry& GetFlagRegistry() const { return FlagRegistry; }
+    FFlagRegistry& GetFlagRegistry() { return FlagRegistry; }
+
+    /** Ordered list of all registered flags (useful for UI enumeration). */
+    const FFlagList& GetAllFlags() const { return FlagList; }
+
+    /** Find a particular debug flag by name. Returns nullptr when not found. */
+    bool* FindFlag(const FName& FlagName);
+
+    // --- Debug switches -----------------------------------------------------
+    bool Verbose = false;
+    bool Performance = false;
+    bool Cache = false;
+    bool Normals = false;
+    bool Error = false;
+    bool Holes = false;
+    bool Landscape = false;
+    bool VoxelConv = false;
+    bool Mesh = false;
+    bool Islands = false;
+    bool Brush = false;
+    bool Context = false;
+    bool UserConv = false;
+    bool IO = false;
+    bool Threads = false;
+    bool Space = false;
+    bool Chunks = false;
+    bool Voxels = false;
+    bool Casts = false;
+    bool Delegates = false;
+    bool Manager = false;
+    bool Caves = false;
+    bool Lights = false;
+    bool Flags = false;
+    bool VoxelModificationReports = false;
+    bool Seams = false;
+
+private:
+    FDiggerDebug();
+
+    void RegisterFlag(const TCHAR* FlagName, bool& FlagRef);
+
+    FFlagRegistry FlagRegistry;
+    FFlagList FlagList;
+};
 
 namespace DiggerDebug
 {
-	inline bool Verbose = false;
-	inline bool Performance = false;
-	inline bool Cache = false;
-	inline bool Normals = false;
-	inline bool Error = false;
-	inline bool Holes = false;
-	inline bool Landscape = false;
-	inline bool VoxelConv = false;
-	inline bool Mesh = false;
-	inline bool Islands = false;
-	inline bool Brush = false;
-	inline bool Context = false;
-	inline bool UserConv = false;
-	inline bool IO = false;
-	inline bool Threads = false;
-	inline bool Space = false;
-	inline bool Chunks = false;
-	inline bool Voxels = false;
-	inline bool Casts = false;
-	inline bool Delegates = false;
-	inline bool Manager = false;
-	inline bool Caves = false;
-	inline bool Lights = false;
-	inline bool Flags = false;
-	inline bool VoxelModificationReports=false;
-	inline bool Seams=false;
+    inline FDiggerDebug& Get() { return FDiggerDebug::Get(); }
+
+    using FDiggerDebugFlag = FDiggerDebug::FFlagEntry;
+
+    inline bool& Verbose = FDiggerDebug::Get().Verbose;
+    inline bool& Performance = FDiggerDebug::Get().Performance;
+    inline bool& Cache = FDiggerDebug::Get().Cache;
+    inline bool& Normals = FDiggerDebug::Get().Normals;
+    inline bool& Error = FDiggerDebug::Get().Error;
+    inline bool& Holes = FDiggerDebug::Get().Holes;
+    inline bool& Landscape = FDiggerDebug::Get().Landscape;
+    inline bool& VoxelConv = FDiggerDebug::Get().VoxelConv;
+    inline bool& Mesh = FDiggerDebug::Get().Mesh;
+    inline bool& Islands = FDiggerDebug::Get().Islands;
+    inline bool& Brush = FDiggerDebug::Get().Brush;
+    inline bool& Context = FDiggerDebug::Get().Context;
+    inline bool& UserConv = FDiggerDebug::Get().UserConv;
+    inline bool& IO = FDiggerDebug::Get().IO;
+    inline bool& Threads = FDiggerDebug::Get().Threads;
+    inline bool& Space = FDiggerDebug::Get().Space;
+    inline bool& Chunks = FDiggerDebug::Get().Chunks;
+    inline bool& Voxels = FDiggerDebug::Get().Voxels;
+    inline bool& Casts = FDiggerDebug::Get().Casts;
+    inline bool& Delegates = FDiggerDebug::Get().Delegates;
+    inline bool& Manager = FDiggerDebug::Get().Manager;
+    inline bool& Caves = FDiggerDebug::Get().Caves;
+    inline bool& Lights = FDiggerDebug::Get().Lights;
+    inline bool& Flags = FDiggerDebug::Get().Flags;
+    inline bool& VoxelModificationReports = FDiggerDebug::Get().VoxelModificationReports;
+    inline bool& Seams = FDiggerDebug::Get().Seams;
+
+    inline FDiggerDebug::FFlagRegistry& GetFlagRegistry()
+    {
+        return FDiggerDebug::Get().GetFlagRegistry();
+    }
+
+    inline const TArray<FDiggerDebugFlag>& GetAllFlags()
+    {
+        return FDiggerDebug::Get().GetAllFlags();
+    }
+
+    inline bool* FindFlag(const FName& FlagName)
+    {
+        return FDiggerDebug::Get().FindFlag(FlagName);
+    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated debug flag entry struct to mirror the old `FDiggerDebugFlag` type while keeping the singleton registry
- expose the alias in the `DiggerDebug` namespace and populate the ordered list through structured emplace calls

## Testing
- not run (Unreal build not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d9529fd404832f8c3d4931c01ffc7f